### PR TITLE
docs: update DeepSeek model example and clean subgroup metadata

### DIFF
--- a/src/main/java/io/kestra/plugin/deepseek/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/deepseek/ChatCompletion.java
@@ -93,7 +93,7 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
     @PluginProperty(group = "main", secret = true)
     private Property<String> apiKey;
 
-    @Schema(title = "Model name", description = "DeepSeek model identifier such as `deepseek-chat` or `deepseek-coder`")
+    @Schema(title = "Model name", description = "DeepSeek model identifier such as `deepseek-chat` or `deepseek-reasoner`")
     @NotNull
     @PluginProperty(group = "main")
     private Property<String> modelName;

--- a/src/main/java/io/kestra/plugin/deepseek/package-info.java
+++ b/src/main/java/io/kestra/plugin/deepseek/package-info.java
@@ -1,6 +1,6 @@
 @PluginSubGroup(
-    title = "DeepSeek plugin",
-    description = "A plugin to use DeepSeek with Kestra.",
+    title = "DeepSeek",
+    description = "Call DeepSeek chat models from Kestra flows for conversational and schema-guided JSON responses.",
     categories = {
         PluginSubGroup.PluginCategory.AI
     }


### PR DESCRIPTION
## Summary

Documentation correctness + completeness review of **plugin-deepseek** (task-level `@Schema`/`@Example` annotations, `package-info.java`, `metadata/index.yaml`, and the how-to doc). Docs-only pass — no behavior, defaults, `@NotNull`, `secret`, or `group` changes. 1 task: `ChatCompletion` (`DeepseekResponseNormalizer` is an internal utility, not a doc surface).

### Doc fixes in this PR

- **Outdated model identifier.** The `modelName` description listed "`deepseek-chat` or `deepseek-coder`". DeepSeek merged the Coder model into the general chat model (V2.5, late 2024); the current API exposes **`deepseek-chat`** and **`deepseek-reasoner`**. Updated the example to `deepseek-reasoner`.
- **Boilerplate `package-info`.** The `@PluginSubGroup` was the generic template text (title "DeepSeek plugin", description "A plugin to use DeepSeek with Kestra."). Replaced with a descriptive title ("DeepSeek") and a summary consistent with the `index.yaml` metadata.

Everything else was accurate and left unchanged: the `ChatCompletion` title/description, both examples (valid YAML, `apiKey` via `secret()`, `deepseek-chat`, JSON-mode schema), `apiKey` (`@NotNull` + `secret = true`), `baseUrl` default (`https://api.deepseek.com/v1`), the `messages`/role model, the `Output` schema (`response`/`raw`), the how-to, and `index.yaml`.

## Engineering flag list (NOT addressed here — code-level, out of scope for a docs pass)

- **`jsonResponseSchema` is in `group = "connection"`.** It is a per-request formatting parameter, not a connection setting — `group = "main"` (or a dedicated group) would fit better. Cosmetic UI grouping only.
- **`DeepseekResponseNormalizer` array detection is a loose substring match.** It flags "expects array" whenever the schema string contains `"type":"array"` anywhere (after whitespace stripping), so a schema whose *root* is an object but which has any nested array property would be treated as array-expecting and could get wrapped in `[...]`. Worth tightening to inspect the root schema type.
- `AGENTS.md` is stale/templated boilerplate — not a doc surface, noting for cleanup.
